### PR TITLE
The analytic Hessian was -2*grad/h; also fix cosine NW gradient and scale-dependent bandwidths

### DIFF
--- a/hbw/_numba_kde.py
+++ b/hbw/_numba_kde.py
@@ -208,7 +208,7 @@ def _cosine_all(u: float) -> tuple[float, float, float, float, float, float]:
         sin_half = math.sin(_PI_2 * absu)
         k2 = _PI / 32.0 * (_PI * (2.0 - absu) * cos_half + 2.0 * sin_half)
         sign_u = 1.0 if u >= 0 else -1.0
-        k2p = sign_u * (-_PI**3 / 64.0) * sin_half * (2.0 - absu)
+        k2p = sign_u * (-(_PI**3) / 64.0) * sin_half * (2.0 - absu)
         k2pp = _PI**3 / 128.0 * (_PI * (absu - 2.0) * cos_half + 2.0 * sin_half)
     else:
         k2 = 0.0
@@ -235,12 +235,12 @@ def lscv_numba_gauss(x: NDArray, h: float) -> tuple[float, float, float]:
 
             local_sums[tid, 0] += k2
             local_sums[tid, 1] += k2 + u * k2p
-            local_sums[tid, 2] += 2.0 * k2p + u * k2pp
+            local_sums[tid, 2] += 2.0 * k2 + 4.0 * u * k2p + u * u * k2pp
 
             if i != j:
                 local_sums[tid, 3] += k
                 local_sums[tid, 4] += k + u * kp
-                local_sums[tid, 5] += 2.0 * kp + u * kpp
+                local_sums[tid, 5] += 2.0 * k + 4.0 * u * kp + u * u * kpp
 
     sum_K2 = local_sums[:, 0].sum()
     sum_SF = local_sums[:, 1].sum()
@@ -256,12 +256,7 @@ def lscv_numba_gauss(x: NDArray, h: float) -> tuple[float, float, float]:
 
     score = sum_K2 / (n2 * h) - 2.0 * sum_K / (nn1 * h)
     grad = -sum_SF / (n2 * h2) + 2.0 * sum_SK / (nn1 * h2)
-    hess = (
-        2.0 * sum_SF / (n2 * h3)
-        - sum_SF2 / (n2 * h2)
-        - 4.0 * sum_SK / (nn1 * h3)
-        + 2.0 * sum_SK2 / (nn1 * h2)
-    )
+    hess = sum_SF2 / (n2 * h3) - 2.0 * sum_SK2 / (nn1 * h3)
 
     return score, grad, hess
 
@@ -314,12 +309,12 @@ def lscv_numba_epan(x: NDArray, h: float) -> tuple[float, float, float]:
 
             local_sums[tid, 0] += k2
             local_sums[tid, 1] += k2 + u * k2p
-            local_sums[tid, 2] += 2.0 * k2p + u * k2pp
+            local_sums[tid, 2] += 2.0 * k2 + 4.0 * u * k2p + u * u * k2pp
 
             if i != j:
                 local_sums[tid, 3] += k
                 local_sums[tid, 4] += k + u * kp
-                local_sums[tid, 5] += 2.0 * kp + u * kpp
+                local_sums[tid, 5] += 2.0 * k + 4.0 * u * kp + u * u * kpp
 
     sum_K2 = local_sums[:, 0].sum()
     sum_SF = local_sums[:, 1].sum()
@@ -335,12 +330,7 @@ def lscv_numba_epan(x: NDArray, h: float) -> tuple[float, float, float]:
 
     score = sum_K2 / (n2 * h) - 2.0 * sum_K / (nn1 * h)
     grad = -sum_SF / (n2 * h2) + 2.0 * sum_SK / (nn1 * h2)
-    hess = (
-        2.0 * sum_SF / (n2 * h3)
-        - sum_SF2 / (n2 * h2)
-        - 4.0 * sum_SK / (nn1 * h3)
-        + 2.0 * sum_SK2 / (nn1 * h2)
-    )
+    hess = sum_SF2 / (n2 * h3) - 2.0 * sum_SK2 / (nn1 * h3)
 
     return score, grad, hess
 
@@ -393,12 +383,12 @@ def lscv_numba_unif(x: NDArray, h: float) -> tuple[float, float, float]:
 
             local_sums[tid, 0] += k2
             local_sums[tid, 1] += k2 + u * k2p
-            local_sums[tid, 2] += 2.0 * k2p + u * k2pp
+            local_sums[tid, 2] += 2.0 * k2 + 4.0 * u * k2p + u * u * k2pp
 
             if i != j:
                 local_sums[tid, 3] += k
                 local_sums[tid, 4] += k + u * kp
-                local_sums[tid, 5] += 2.0 * kp + u * kpp
+                local_sums[tid, 5] += 2.0 * k + 4.0 * u * kp + u * u * kpp
 
     sum_K2 = local_sums[:, 0].sum()
     sum_SF = local_sums[:, 1].sum()
@@ -414,12 +404,7 @@ def lscv_numba_unif(x: NDArray, h: float) -> tuple[float, float, float]:
 
     score = sum_K2 / (n2 * h) - 2.0 * sum_K / (nn1 * h)
     grad = -sum_SF / (n2 * h2) + 2.0 * sum_SK / (nn1 * h2)
-    hess = (
-        2.0 * sum_SF / (n2 * h3)
-        - sum_SF2 / (n2 * h2)
-        - 4.0 * sum_SK / (nn1 * h3)
-        + 2.0 * sum_SK2 / (nn1 * h2)
-    )
+    hess = sum_SF2 / (n2 * h3) - 2.0 * sum_SK2 / (nn1 * h3)
 
     return score, grad, hess
 
@@ -471,12 +456,12 @@ def lscv_numba_biweight(x: NDArray, h: float) -> tuple[float, float, float]:
 
             local_sums[tid, 0] += k2
             local_sums[tid, 1] += k2 + u * k2p
-            local_sums[tid, 2] += 2.0 * k2p + u * k2pp
+            local_sums[tid, 2] += 2.0 * k2 + 4.0 * u * k2p + u * u * k2pp
 
             if i != j:
                 local_sums[tid, 3] += k
                 local_sums[tid, 4] += k + u * kp
-                local_sums[tid, 5] += 2.0 * kp + u * kpp
+                local_sums[tid, 5] += 2.0 * k + 4.0 * u * kp + u * u * kpp
 
     sum_K2 = local_sums[:, 0].sum()
     sum_SF = local_sums[:, 1].sum()
@@ -492,12 +477,7 @@ def lscv_numba_biweight(x: NDArray, h: float) -> tuple[float, float, float]:
 
     score = sum_K2 / (n2 * h) - 2.0 * sum_K / (nn1 * h)
     grad = -sum_SF / (n2 * h2) + 2.0 * sum_SK / (nn1 * h2)
-    hess = (
-        2.0 * sum_SF / (n2 * h3)
-        - sum_SF2 / (n2 * h2)
-        - 4.0 * sum_SK / (nn1 * h3)
-        + 2.0 * sum_SK2 / (nn1 * h2)
-    )
+    hess = sum_SF2 / (n2 * h3) - 2.0 * sum_SK2 / (nn1 * h3)
 
     return score, grad, hess
 
@@ -559,12 +539,12 @@ def lscv_numba_triweight(x: NDArray, h: float) -> tuple[float, float, float]:
 
             local_sums[tid, 0] += k2
             local_sums[tid, 1] += k2 + u * k2p
-            local_sums[tid, 2] += 2.0 * k2p + u * k2pp
+            local_sums[tid, 2] += 2.0 * k2 + 4.0 * u * k2p + u * u * k2pp
 
             if i != j:
                 local_sums[tid, 3] += k
                 local_sums[tid, 4] += k + u * kp
-                local_sums[tid, 5] += 2.0 * kp + u * kpp
+                local_sums[tid, 5] += 2.0 * k + 4.0 * u * kp + u * u * kpp
 
     sum_K2 = local_sums[:, 0].sum()
     sum_SF = local_sums[:, 1].sum()
@@ -580,12 +560,7 @@ def lscv_numba_triweight(x: NDArray, h: float) -> tuple[float, float, float]:
 
     score = sum_K2 / (n2 * h) - 2.0 * sum_K / (nn1 * h)
     grad = -sum_SF / (n2 * h2) + 2.0 * sum_SK / (nn1 * h2)
-    hess = (
-        2.0 * sum_SF / (n2 * h3)
-        - sum_SF2 / (n2 * h2)
-        - 4.0 * sum_SK / (nn1 * h3)
-        + 2.0 * sum_SK2 / (nn1 * h2)
-    )
+    hess = sum_SF2 / (n2 * h3) - 2.0 * sum_SK2 / (nn1 * h3)
 
     return score, grad, hess
 
@@ -649,12 +624,12 @@ def lscv_numba_cosine(x: NDArray, h: float) -> tuple[float, float, float]:
 
             local_sums[tid, 0] += k2
             local_sums[tid, 1] += k2 + u * k2p
-            local_sums[tid, 2] += 2.0 * k2p + u * k2pp
+            local_sums[tid, 2] += 2.0 * k2 + 4.0 * u * k2p + u * u * k2pp
 
             if i != j:
                 local_sums[tid, 3] += k
                 local_sums[tid, 4] += k + u * kp
-                local_sums[tid, 5] += 2.0 * kp + u * kpp
+                local_sums[tid, 5] += 2.0 * k + 4.0 * u * kp + u * u * kpp
 
     sum_K2 = local_sums[:, 0].sum()
     sum_SF = local_sums[:, 1].sum()
@@ -670,12 +645,7 @@ def lscv_numba_cosine(x: NDArray, h: float) -> tuple[float, float, float]:
 
     score = sum_K2 / (n2 * h) - 2.0 * sum_K / (nn1 * h)
     grad = -sum_SF / (n2 * h2) + 2.0 * sum_SK / (nn1 * h2)
-    hess = (
-        2.0 * sum_SF / (n2 * h3)
-        - sum_SF2 / (n2 * h2)
-        - 4.0 * sum_SK / (nn1 * h3)
-        + 2.0 * sum_SK2 / (nn1 * h2)
-    )
+    hess = sum_SF2 / (n2 * h3) - 2.0 * sum_SK2 / (nn1 * h3)
 
     return score, grad, hess
 
@@ -751,24 +721,24 @@ def lscv_mv_numba_gauss(data: NDArray, h: float) -> tuple[float, float, float]:
                 if k > 0:
                     r = kp / k
                     sum_ratio_k += u * r
-                    sum_d2_k += 2.0 * u * r + u * u * kpp / k
+                    sum_d2_k += u * u * (kpp / k - r * r)
 
                 if k2 > 0:
                     r2 = k2p / k2
                     sum_ratio_k2 += u * r2
-                    sum_d2_k2 += 2.0 * u * r2 + u * u * k2pp / k2
+                    sum_d2_k2 += u * u * (k2pp / k2 - r2 * r2)
 
             local_sums[tid, 0] += prod_k2
             local_sums[tid, 1] += prod_k2 * (d + sum_ratio_k2)
             local_sums[tid, 2] += prod_k2 * (
-                (d + 1) * d + 2.0 * (d + 1) * sum_ratio_k2 + sum_d2_k2
+                (d + 1) * d + 2.0 * (d + 1) * sum_ratio_k2 + sum_ratio_k2 * sum_ratio_k2 + sum_d2_k2
             )
 
             if i != j:
                 local_sums[tid, 3] += prod_k
                 local_sums[tid, 4] += prod_k * (d + sum_ratio_k)
                 local_sums[tid, 5] += prod_k * (
-                    (d + 1) * d + 2.0 * (d + 1) * sum_ratio_k + sum_d2_k
+                    (d + 1) * d + 2.0 * (d + 1) * sum_ratio_k + sum_ratio_k * sum_ratio_k + sum_d2_k
                 )
 
     sum_K2 = local_sums[:, 0].sum()
@@ -786,12 +756,7 @@ def lscv_mv_numba_gauss(data: NDArray, h: float) -> tuple[float, float, float]:
 
     score = sum_K2 / (n2 * hd) - 2.0 * sum_K / (nn1 * hd)
     grad = -sum_SF / (n2 * hd1) + 2.0 * sum_SK / (nn1 * hd1)
-    hess = (
-        (d + 1) * sum_SF / (n2 * hd2)
-        - sum_SF2 / (n2 * hd1)
-        - 2.0 * (d + 1) * sum_SK / (nn1 * hd2)
-        + 2.0 * sum_SK2 / (nn1 * hd1)
-    )
+    hess = sum_SF2 / (n2 * hd2) - 2.0 * sum_SK2 / (nn1 * hd2)
 
     return score, grad, hess
 

--- a/hbw/_numba_nw.py
+++ b/hbw/_numba_nw.py
@@ -43,7 +43,7 @@ def loocv_numba_gauss(x: NDArray, y: NDArray, h: float) -> tuple[float, float, f
             exp_val = math.exp(-0.5 * u2)
             w = exp_val / (_SQRT_2PI * h)
             wp = w * (u2 - 1.0) / h
-            wpp = w * (u2 * u2 - 3.0 * u2 + 1.0) / h2
+            wpp = w * (u2 * u2 - 5.0 * u2 + 2.0) / h2
 
             yi = y[i]
             num += w * yi
@@ -53,6 +53,9 @@ def loocv_numba_gauss(x: NDArray, y: NDArray, h: float) -> tuple[float, float, f
             num_pp += wpp * yi
             den_pp += wpp
 
+        # The loss must be accumulated even when every weight underflowed
+        # (den == 0, m = 0), or h -> 0 reports a loss of 0 and looks optimal.
+        # The derivatives of m are undefined there, so they contribute nothing.
         if den > 0:
             m = num / den
             den2 = den * den
@@ -68,6 +71,8 @@ def loocv_numba_gauss(x: NDArray, y: NDArray, h: float) -> tuple[float, float, f
             local_loss[tid] += resid * resid
             local_grad[tid] += -2.0 * resid * mp
             local_hess[tid] += 2.0 * (mp * mp - resid * mpp)
+        else:
+            local_loss[tid] += y[j] * y[j]
 
     inv_n = 1.0 / n
     return local_loss.sum() * inv_n, local_grad.sum() * inv_n, local_hess.sum() * inv_n
@@ -98,10 +103,12 @@ def loocv_score_numba_gauss(x: NDArray, y: NDArray, h: float) -> float:
             num += w * y[i]
             den += w
 
-        if den > 0:
-            m = num / den
-            resid = y[j] - m
-            local_loss[tid] += resid * resid
+        # den == 0 means every weight underflowed; the NumPy reference then
+        # yields m = 0. Skipping the point instead would report a loss of 0
+        # and make h -> 0 look like a global minimum.
+        m = num / den if den > 0 else 0.0
+        resid = y[j] - m
+        local_loss[tid] += resid * resid
 
     return local_loss.sum() / n
 
@@ -152,6 +159,9 @@ def loocv_numba_epan(x: NDArray, y: NDArray, h: float) -> tuple[float, float, fl
                 num_pp += wpp * yi
                 den_pp += wpp
 
+        # The loss must be accumulated even when every weight underflowed
+        # (den == 0, m = 0), or h -> 0 reports a loss of 0 and looks optimal.
+        # The derivatives of m are undefined there, so they contribute nothing.
         if den > 0:
             m = num / den
             den2 = den * den
@@ -167,6 +177,8 @@ def loocv_numba_epan(x: NDArray, y: NDArray, h: float) -> tuple[float, float, fl
             local_loss[tid] += resid * resid
             local_grad[tid] += -2.0 * resid * mp
             local_hess[tid] += 2.0 * (mp * mp - resid * mpp)
+        else:
+            local_loss[tid] += y[j] * y[j]
 
     inv_n = 1.0 / n
     return local_loss.sum() * inv_n, local_grad.sum() * inv_n, local_hess.sum() * inv_n
@@ -197,10 +209,12 @@ def loocv_score_numba_epan(x: NDArray, y: NDArray, h: float) -> float:
                 num += w * y[i]
                 den += w
 
-        if den > 0:
-            m = num / den
-            resid = y[j] - m
-            local_loss[tid] += resid * resid
+        # den == 0 means every weight underflowed; the NumPy reference then
+        # yields m = 0. Skipping the point instead would report a loss of 0
+        # and make h -> 0 look like a global minimum.
+        m = num / den if den > 0 else 0.0
+        resid = y[j] - m
+        local_loss[tid] += resid * resid
 
     return local_loss.sum() / n
 
@@ -247,6 +261,9 @@ def loocv_numba_unif(x: NDArray, y: NDArray, h: float) -> tuple[float, float, fl
                 num_pp += wpp * yi
                 den_pp += wpp
 
+        # The loss must be accumulated even when every weight underflowed
+        # (den == 0, m = 0), or h -> 0 reports a loss of 0 and looks optimal.
+        # The derivatives of m are undefined there, so they contribute nothing.
         if den > 0:
             m = num / den
             den2 = den * den
@@ -262,6 +279,8 @@ def loocv_numba_unif(x: NDArray, y: NDArray, h: float) -> tuple[float, float, fl
             local_loss[tid] += resid * resid
             local_grad[tid] += -2.0 * resid * mp
             local_hess[tid] += 2.0 * (mp * mp - resid * mpp)
+        else:
+            local_loss[tid] += y[j] * y[j]
 
     inv_n = 1.0 / n
     return local_loss.sum() * inv_n, local_grad.sum() * inv_n, local_hess.sum() * inv_n
@@ -291,10 +310,12 @@ def loocv_score_numba_unif(x: NDArray, y: NDArray, h: float) -> float:
                 num += w * y[i]
                 den += w
 
-        if den > 0:
-            m = num / den
-            resid = y[j] - m
-            local_loss[tid] += resid * resid
+        # den == 0 means every weight underflowed; the NumPy reference then
+        # yields m = 0. Skipping the point instead would report a loss of 0
+        # and make h -> 0 look like a global minimum.
+        m = num / den if den > 0 else 0.0
+        resid = y[j] - m
+        local_loss[tid] += resid * resid
 
     return local_loss.sum() / n
 
@@ -337,7 +358,7 @@ def loocv_numba_biweight(x: NDArray, y: NDArray, h: float) -> tuple[float, float
 
                 wp = (15.0 / 16.0) * one_minus_u2 * (5.0 * u2 - 1.0) / h2
 
-                wpp = (15.0 / 8.0) * (1.0 - 12.0 * u2 + 20.0 * u2 * u2 - 5.0 * u2 * u2 * u2) / h3
+                wpp = (15.0 / 8.0) * (1.0 - 12.0 * u2 + 15.0 * u2 * u2) / h3
 
                 yi = y[i]
                 num += w * yi
@@ -347,6 +368,9 @@ def loocv_numba_biweight(x: NDArray, y: NDArray, h: float) -> tuple[float, float
                 num_pp += wpp * yi
                 den_pp += wpp
 
+        # The loss must be accumulated even when every weight underflowed
+        # (den == 0, m = 0), or h -> 0 reports a loss of 0 and looks optimal.
+        # The derivatives of m are undefined there, so they contribute nothing.
         if den > 0:
             m = num / den
             den2 = den * den
@@ -362,6 +386,8 @@ def loocv_numba_biweight(x: NDArray, y: NDArray, h: float) -> tuple[float, float
             local_loss[tid] += resid * resid
             local_grad[tid] += -2.0 * resid * mp
             local_hess[tid] += 2.0 * (mp * mp - resid * mpp)
+        else:
+            local_loss[tid] += y[j] * y[j]
 
     inv_n = 1.0 / n
     return local_loss.sum() * inv_n, local_grad.sum() * inv_n, local_hess.sum() * inv_n
@@ -394,10 +420,12 @@ def loocv_score_numba_biweight(x: NDArray, y: NDArray, h: float) -> float:
                 num += w * y[i]
                 den += w
 
-        if den > 0:
-            m = num / den
-            resid = y[j] - m
-            local_loss[tid] += resid * resid
+        # den == 0 means every weight underflowed; the NumPy reference then
+        # yields m = 0. Skipping the point instead would report a loss of 0
+        # and make h -> 0 look like a global minimum.
+        m = num / den if den > 0 else 0.0
+        resid = y[j] - m
+        local_loss[tid] += resid * resid
 
     return local_loss.sum() / n
 
@@ -441,12 +469,7 @@ def loocv_numba_triweight(x: NDArray, y: NDArray, h: float) -> tuple[float, floa
 
                 wp = (35.0 / 32.0) * one_minus_u2_sq * (7.0 * u2 - 1.0) / h2
 
-                wpp = (
-                    (35.0 / 16.0)
-                    * one_minus_u2
-                    * (1.0 - 20.0 * u2 + 35.0 * u2 * u2)
-                    / h3
-                )
+                wpp = (35.0 / 16.0) * (1.0 - 18.0 * u2 + 45.0 * u2 * u2 - 28.0 * u2 * u2 * u2) / h3
 
                 yi = y[i]
                 num += w * yi
@@ -456,6 +479,9 @@ def loocv_numba_triweight(x: NDArray, y: NDArray, h: float) -> tuple[float, floa
                 num_pp += wpp * yi
                 den_pp += wpp
 
+        # The loss must be accumulated even when every weight underflowed
+        # (den == 0, m = 0), or h -> 0 reports a loss of 0 and looks optimal.
+        # The derivatives of m are undefined there, so they contribute nothing.
         if den > 0:
             m = num / den
             den2 = den * den
@@ -471,6 +497,8 @@ def loocv_numba_triweight(x: NDArray, y: NDArray, h: float) -> tuple[float, floa
             local_loss[tid] += resid * resid
             local_grad[tid] += -2.0 * resid * mp
             local_hess[tid] += 2.0 * (mp * mp - resid * mpp)
+        else:
+            local_loss[tid] += y[j] * y[j]
 
     inv_n = 1.0 / n
     return local_loss.sum() * inv_n, local_grad.sum() * inv_n, local_hess.sum() * inv_n
@@ -503,10 +531,12 @@ def loocv_score_numba_triweight(x: NDArray, y: NDArray, h: float) -> float:
                 num += w * y[i]
                 den += w
 
-        if den > 0:
-            m = num / den
-            resid = y[j] - m
-            local_loss[tid] += resid * resid
+        # den == 0 means every weight underflowed; the NumPy reference then
+        # yields m = 0. Skipping the point instead would report a loss of 0
+        # and make h -> 0 look like a global minimum.
+        m = num / den if den > 0 else 0.0
+        resid = y[j] - m
+        local_loss[tid] += resid * resid
 
     return local_loss.sum() / n
 
@@ -548,20 +578,10 @@ def loocv_numba_cosine(x: NDArray, y: NDArray, h: float) -> tuple[float, float, 
                 k = _PI_4 * cos_val
                 w = k / h
 
-                wp = (
-                    _PI_4
-                    * ((_PI * _PI * u2 / 4.0 - 1.0) * cos_val - (_PI_2 * u) * sin_val)
-                    / h2
-                )
+                wp = _PI_4 * (-cos_val + (_PI_2 * u) * sin_val) / h2
 
                 wpp = (
-                    _PI_4
-                    * (
-                        (2.0 - 3.0 * _PI * _PI * u2 / 2.0 + _PI**4 * u2 * u2 / 16.0)
-                        * cos_val
-                        + (3.0 * _PI_2 * u - _PI**3 * u2 * u / 8.0) * sin_val
-                    )
-                    / h3
+                    _PI_4 * ((2.0 - _PI * _PI * u2 / 4.0) * cos_val - 2.0 * _PI * u * sin_val) / h3
                 )
 
                 yi = y[i]
@@ -572,6 +592,9 @@ def loocv_numba_cosine(x: NDArray, y: NDArray, h: float) -> tuple[float, float, 
                 num_pp += wpp * yi
                 den_pp += wpp
 
+        # The loss must be accumulated even when every weight underflowed
+        # (den == 0, m = 0), or h -> 0 reports a loss of 0 and looks optimal.
+        # The derivatives of m are undefined there, so they contribute nothing.
         if den > 0:
             m = num / den
             den2 = den * den
@@ -587,6 +610,8 @@ def loocv_numba_cosine(x: NDArray, y: NDArray, h: float) -> tuple[float, float, 
             local_loss[tid] += resid * resid
             local_grad[tid] += -2.0 * resid * mp
             local_hess[tid] += 2.0 * (mp * mp - resid * mpp)
+        else:
+            local_loss[tid] += y[j] * y[j]
 
     inv_n = 1.0 / n
     return local_loss.sum() * inv_n, local_grad.sum() * inv_n, local_hess.sum() * inv_n
@@ -617,10 +642,12 @@ def loocv_score_numba_cosine(x: NDArray, y: NDArray, h: float) -> float:
                 num += w * y[i]
                 den += w
 
-        if den > 0:
-            m = num / den
-            resid = y[j] - m
-            local_loss[tid] += resid * resid
+        # den == 0 means every weight underflowed; the NumPy reference then
+        # yields m = 0. Skipping the point instead would report a loss of 0
+        # and make h -> 0 look like a global minimum.
+        m = num / den if den > 0 else 0.0
+        resid = y[j] - m
+        local_loss[tid] += resid * resid
 
     return local_loss.sum() / n
 
@@ -663,11 +690,13 @@ def loocv_mv_numba_gauss(data: NDArray, y: NDArray, h: float) -> tuple[float, fl
                 if k > 0:
                     r = -u
                     sum_ratio += u * r
-                    sum_d2 += 2.0 * u * r + u2 * (u2 - 1.0 - r * r)
+                    sum_d2 += u2 * (u2 - 1.0 - r * r)
 
             w = prod_k / h_d
             wp = -(w / h) * (d + sum_ratio)
-            wpp = (w / (h * h)) * ((d + 1) * d + 2.0 * (d + 1) * sum_ratio + sum_d2)
+            wpp = (w / (h * h)) * (
+                (d + 1) * d + 2.0 * (d + 1) * sum_ratio + sum_ratio * sum_ratio + sum_d2
+            )
 
             yi = y[i]
             num += w * yi
@@ -677,6 +706,9 @@ def loocv_mv_numba_gauss(data: NDArray, y: NDArray, h: float) -> tuple[float, fl
             num_pp += wpp * yi
             den_pp += wpp
 
+        # The loss must be accumulated even when every weight underflowed
+        # (den == 0, m = 0), or h -> 0 reports a loss of 0 and looks optimal.
+        # The derivatives of m are undefined there, so they contribute nothing.
         if den > 0:
             m = num / den
             den2 = den * den
@@ -692,6 +724,8 @@ def loocv_mv_numba_gauss(data: NDArray, y: NDArray, h: float) -> tuple[float, fl
             local_loss[tid] += resid * resid
             local_grad[tid] += -2.0 * resid * mp
             local_hess[tid] += 2.0 * (mp * mp - resid * mpp)
+        else:
+            local_loss[tid] += y[j] * y[j]
 
     inv_n = 1.0 / n
     return local_loss.sum() * inv_n, local_grad.sum() * inv_n, local_hess.sum() * inv_n
@@ -726,10 +760,12 @@ def loocv_score_mv_numba_gauss(data: NDArray, y: NDArray, h: float) -> float:
             num += w * y[i]
             den += w
 
-        if den > 0:
-            m = num / den
-            resid = y[j] - m
-            local_loss[tid] += resid * resid
+        # den == 0 means every weight underflowed; the NumPy reference then
+        # yields m = 0. Skipping the point instead would report a loss of 0
+        # and make h -> 0 look like a global minimum.
+        m = num / den if den > 0 else 0.0
+        resid = y[j] - m
+        local_loss[tid] += resid * resid
 
     return local_loss.sum() / n
 

--- a/hbw/_optim.py
+++ b/hbw/_optim.py
@@ -35,7 +35,7 @@ def _subsample(
     return x_sub, y_sub
 
 
-def _grad_converged(g: float, h: float, f: float, tol: float) -> bool:
+def _grad_converged(g: float, h: float, f: float, hess: float, tol: float) -> bool:
     """Test gradient convergence on a scale-free footing.
 
     An absolute test ``|g| < tol`` is not usable here because the criteria are
@@ -54,6 +54,8 @@ def _grad_converged(g: float, h: float, f: float, tol: float) -> bool:
         Current bandwidth.
     f
         Value of the criterion at ``h``.
+    hess
+        Hessian of the criterion at ``h``.
     tol
         Relative tolerance.
 
@@ -66,11 +68,19 @@ def _grad_converged(g: float, h: float, f: float, tol: float) -> bool:
     if not np.isfinite(scale):
         return False
     if scale == 0.0:
-        # A criterion passing through zero used to make this return False
-        # forever, so the iteration ran to its cap with nothing left to gain.
-        # Fall back to an absolute test at that single point.
-        return abs(g) * h < tol
+        if g == 0.0:
+            return True
+        if hess > 0.0 and np.isfinite(hess):
+            return abs(g / hess) < tol * h
+        return False
     return abs(g) * h < tol * scale
+
+
+def _bandwidth_floor(h_reference: float, ratio: float = 1e-6) -> float:
+    """Return a positive floor that scales with the bandwidth problem."""
+    if not np.isfinite(h_reference) or h_reference <= 0.0:
+        raise ValueError(f"initial bandwidth must be finite and positive, got {h_reference!r}")
+    return max(ratio * h_reference, np.nextafter(0.0, 1.0))
 
 
 def _newton_step(g: float, hess: float, h: float) -> float:
@@ -225,11 +235,12 @@ def _newton_armijo(
 
     def _run_from(h_start: float) -> tuple[float, float]:
         h = h_start
+        h_floor = _bandwidth_floor(h_start)
         f, g, H = _eval_full(h)
         f_prev = float("inf")
 
         for _ in range(max_iter):
-            if _grad_converged(g, h, f, tol):
+            if _grad_converged(g, h, f, H, tol):
                 break
             if abs(f - f_prev) < 1e-8 * abs(f):
                 break
@@ -239,7 +250,7 @@ def _newton_armijo(
             if step == 0.0:
                 break
 
-            accepted = _line_search(_eval_score, h, step, f, 1e-6)
+            accepted = _line_search(_eval_score, h, step, f, h_floor)
             if accepted is None:
                 break
             h = accepted[0]

--- a/hbw/_optim.py
+++ b/hbw/_optim.py
@@ -63,8 +63,13 @@ def _grad_converged(g: float, h: float, f: float, tol: float) -> bool:
         True when the scaled gradient is below ``tol``.
     """
     scale = abs(f)
-    if not np.isfinite(scale) or scale == 0.0:
+    if not np.isfinite(scale):
         return False
+    if scale == 0.0:
+        # A criterion passing through zero used to make this return False
+        # forever, so the iteration ran to its cap with nothing left to gain.
+        # Fall back to an absolute test at that single point.
+        return abs(g) * h < tol
     return abs(g) * h < tol * scale
 
 
@@ -115,6 +120,15 @@ def _line_search(
     binds long before the minimum. Doubling while the score keeps falling
     escapes such a region. Near a genuine quadratic minimum the first doubling
     is rejected immediately, so Newton's fast local convergence is preserved.
+
+    Known limitation: the accepted point is the last one that improved, which
+    can lie past the nearest minimum -- on a multi-modal criterion that is
+    enough to settle in a neighbouring basin. This is why 1-D cosine can land
+    on a local minimum 0.03% worse in objective than a dense grid. Refining the
+    bracket the overshoot leaves behind was tried and rejected: every variant
+    needed an absolute floor or tolerance somewhere, which reintroduced the
+    scale dependence this module exists to remove. If it is revisited, the
+    invariant to hold is h(c*x) == c*h(x) to 1e-6, per test_newton.py.
 
     Parameters
     ----------

--- a/hbw/_optim.py
+++ b/hbw/_optim.py
@@ -1,5 +1,6 @@
 """Newton-Armijo optimizer for bandwidth selection."""
 
+import math
 from collections.abc import Callable
 from typing import Any
 
@@ -34,6 +35,134 @@ def _subsample(
     return x_sub, y_sub
 
 
+def _grad_converged(g: float, h: float, f: float, tol: float) -> bool:
+    """Test gradient convergence on a scale-free footing.
+
+    An absolute test ``|g| < tol`` is not usable here because the criteria are
+    only scale-*equivariant*, not scale-invariant: replacing ``x`` by ``c * x``
+    sends the LSCV minimiser to ``c * h`` while its gradient shrinks like
+    ``1 / c**2`` (LOOCV-MSE: like ``1 / c``). With a fixed absolute tolerance,
+    data in large units looks converged at the starting guess and the optimiser
+    returns Silverman's rule untouched. The dimensionless ratio ``|g| * h / |f|``
+    is invariant under ``x -> c * x`` for both criteria, so test that instead.
+
+    Parameters
+    ----------
+    g
+        Gradient of the criterion at ``h``.
+    h
+        Current bandwidth.
+    f
+        Value of the criterion at ``h``.
+    tol
+        Relative tolerance.
+
+    Returns
+    -------
+    bool
+        True when the scaled gradient is below ``tol``.
+    """
+    scale = abs(f)
+    if not np.isfinite(scale) or scale == 0.0:
+        return False
+    return abs(g) * h < tol * scale
+
+
+def _newton_step(g: float, hess: float, h: float) -> float:
+    """Return a trial step: the Newton step, capped above and floored below.
+
+    Parameters
+    ----------
+    g
+        Gradient at ``h``.
+    hess
+        Hessian at ``h``.
+    h
+        Current bandwidth.
+
+    Returns
+    -------
+    float
+        Trial step, zero only when the gradient vanishes.
+    """
+    if g == 0.0:
+        return 0.0
+    if hess > 0 and np.isfinite(hess):
+        step = float(np.clip(-g / hess, -0.5 * h, 0.5 * h))
+    else:
+        step = math.copysign(0.1 * h, -g)
+    if abs(step) < 1e-3 * h:
+        step = math.copysign(1e-3 * h, step if step != 0.0 else -g)
+    return step
+
+
+def _line_search(
+    score_at: Callable[[float], float],
+    h: float,
+    step: float,
+    f: float,
+    h_floor: float,
+    n_back: int = 4,
+    n_forward: int = 12,
+) -> tuple[float, float] | None:
+    """Armijo backtracking with forward-tracking, along a descent direction.
+
+    Backtracking alone is not enough here. The compactly supported kernels are
+    only C0, so every pair entering or leaving the kernel support puts a kink in
+    the criterion. Local curvature is then dominated by those kinks and grossly
+    overstates the curvature of the criterion's global shape, which makes the
+    honest Newton step far too short: the iterate crawls and the iteration cap
+    binds long before the minimum. Doubling while the score keeps falling
+    escapes such a region. Near a genuine quadratic minimum the first doubling
+    is rejected immediately, so Newton's fast local convergence is preserved.
+
+    Parameters
+    ----------
+    score_at
+        Function returning the criterion at a bandwidth.
+    h
+        Current bandwidth.
+    step
+        Trial step (must point downhill).
+    f
+        Criterion value at ``h``.
+    h_floor
+        Smallest admissible bandwidth.
+    n_back
+        Maximum number of step halvings.
+    n_forward
+        Maximum number of step doublings.
+
+    Returns
+    -------
+    tuple[float, float] | None
+        The accepted ``(bandwidth, score)``, or None if no decrease was found.
+    """
+    h_new = max(h + step, h_floor)
+    f_new = score_at(h_new)
+    if not f_new < f:
+        for _ in range(n_back):
+            step *= 0.5
+            h_new = max(h + step, h_floor)
+            f_new = score_at(h_new)
+            if f_new < f:
+                break
+        else:
+            return None
+
+    for _ in range(n_forward):
+        step_try = 2.0 * step
+        h_try = max(h + step_try, h_floor)
+        if h_try == h_new:
+            break
+        f_try = score_at(h_try)
+        if not f_try < f_new:
+            break
+        step, h_new, f_new = step_try, h_try, f_try
+
+    return h_new, f_new
+
+
 def _newton_armijo(
     objective: Callable[..., tuple[float, float, float]],
     x: NDArray[Any],
@@ -59,7 +188,7 @@ def _newton_armijo(
     kernel
         Kernel name.
     tol
-        Convergence tolerance on gradient.
+        Relative convergence tolerance on the scaled gradient ``|g| * h / |f|``.
     max_iter
         Maximum Newton iterations.
     score_only
@@ -86,38 +215,21 @@ def _newton_armijo(
         f_prev = float("inf")
 
         for _ in range(max_iter):
-            if abs(g) < tol:
+            if _grad_converged(g, h, f, tol):
                 break
             if abs(f - f_prev) < 1e-8 * abs(f):
                 break
             f_prev = f
 
-            if H > 0 and np.isfinite(H):
-                step = -g / H
-                step = np.clip(step, -0.5 * h, 0.5 * h)
-            else:
-                step = 0.1 * h * np.sign(-g) if g != 0 else 0.0
-            if abs(step) / h < 1e-3:
+            step = _newton_step(g, H, h)
+            if step == 0.0:
                 break
 
-            h_new = max(h + step, 1e-6)
-            f_new = _eval_score(h_new)
-
-            if f_new < f:
-                h = h_new
-                f, g, H = _eval_full(h)
-                continue
-
-            for _ in range(4):
-                step *= 0.5
-                h_new = max(h + step, 1e-6)
-                f_new = _eval_score(h_new)
-                if f_new < f:
-                    h = h_new
-                    f, g, H = _eval_full(h)
-                    break
-            else:
+            accepted = _line_search(_eval_score, h, step, f, 1e-6)
+            if accepted is None:
                 break
+            h = accepted[0]
+            f, g, H = _eval_full(h)
 
         return h, f
 

--- a/hbw/kde.py
+++ b/hbw/kde.py
@@ -22,7 +22,14 @@ from ._numba_kde import (
     lscv_score_numba_triweight,
     lscv_score_numba_unif,
 )
-from ._optim import _newton_armijo, _silverman_h, _subsample
+from ._optim import (
+    _grad_converged,
+    _line_search,
+    _newton_armijo,
+    _newton_step,
+    _silverman_h,
+    _subsample,
+)
 
 
 def lscv_score(x: NDArray[Any], h: float, kernel: str = "gauss") -> float:
@@ -132,11 +139,11 @@ def lscv(x: NDArray[Any], h: float, kernel: str = "gauss") -> tuple[float, float
     S_K = S_K_matrix.sum() - np.trace(S_K_matrix)
     grad = float(-S_F / (n**2 * h**2) + 2 * S_K / (n * (n - 1) * h**2))
 
-    S_F2 = (2 * K2p_u + u * K2pp_u).sum()
-    S_K2_matrix = 2 * Kp_u + u * Kpp_u
+    # d2/dh2 [ h^-1 f(delta/h) ] = h^-3 ( 2f + 4u f' + u^2 f'' ), with u = delta/h.
+    S_F2 = (2 * K2_u + 4 * u * K2p_u + u * u * K2pp_u).sum()
+    S_K2_matrix = 2 * K_u + 4 * u * Kp_u + u * u * Kpp_u
     S_K2 = S_K2_matrix.sum() - np.trace(S_K2_matrix)
-    hess = 2 * S_F / (n**2 * h**3) - S_F2 / (n**2 * h**2)
-    hess += -4 * S_K / (n * (n - 1) * h**3) + 2 * S_K2 / (n * (n - 1) * h**2)
+    hess = S_F2 / (n**2 * h**3) - 2 * S_K2 / (n * (n - 1) * h**3)
     return score, grad, float(hess)
 
 
@@ -286,27 +293,29 @@ def lscv_mv(data: NDArray[Any], h: float, kernel: str = "gauss") -> tuple[float,
     Kpp_vals = Kpp(U)
     K2pp_vals = K2pp(U)
 
+    # With A = prod_k f(U_k) and L = sum_k U_k d/dU_k,
+    # d2/dh2 [ h^-d A ] = h^-(d+2) ( d(d+1) A + (2d+1) LA + L^2 A )
+    #                   = h^-(d+2) A ( d(d+1) + 2(d+1) S + S^2
+    #                                  + sum_k U_k^2 (f''/f - (f'/f)^2) ),
+    # where S = sum_k U_k f'(U_k)/f(U_k).
     d2_K2 = np.zeros((n, n))
     for k in range(d):
         with np.errstate(divide="ignore", invalid="ignore"):
             r1 = np.where(K2_vals[:, :, k] != 0, K2p_vals[:, :, k] / K2_vals[:, :, k], 0)
             r2 = np.where(K2_vals[:, :, k] != 0, K2pp_vals[:, :, k] / K2_vals[:, :, k], 0)
-        d2_K2 += 2 * U[:, :, k] * r1 + U[:, :, k] ** 2 * r2
-    S_F2 = (K2_prod * ((d + 1) * d + 2 * (d + 1) * sum_K2_ratio + d2_K2)).sum()
+        d2_K2 += U[:, :, k] ** 2 * (r2 - r1 * r1)
+    S_F2 = (K2_prod * ((d + 1) * d + 2 * (d + 1) * sum_K2_ratio + sum_K2_ratio**2 + d2_K2)).sum()
 
     d2_K = np.zeros((n, n))
     for k in range(d):
         with np.errstate(divide="ignore", invalid="ignore"):
             r1 = np.where(K_vals[:, :, k] != 0, Kp_vals[:, :, k] / K_vals[:, :, k], 0)
             r2 = np.where(K_vals[:, :, k] != 0, Kpp_vals[:, :, k] / K_vals[:, :, k], 0)
-        d2_K += 2 * U[:, :, k] * r1 + U[:, :, k] ** 2 * r2
-    S_K2_matrix = K_prod * ((d + 1) * d + 2 * (d + 1) * sum_K_ratio + d2_K)
+        d2_K += U[:, :, k] ** 2 * (r2 - r1 * r1)
+    S_K2_matrix = K_prod * ((d + 1) * d + 2 * (d + 1) * sum_K_ratio + sum_K_ratio**2 + d2_K)
     S_K2 = S_K2_matrix.sum() - np.trace(S_K2_matrix)
 
-    hess = (d + 1) * S_F / (n**2 * h ** (d + 2)) - S_F2 / (n**2 * h ** (d + 1))
-    hess += -2 * (d + 1) * S_K / (n * (n - 1) * h ** (d + 2)) + 2 * S_K2 / (
-        n * (n - 1) * h ** (d + 1)
-    )
+    hess = S_F2 / (n**2 * h ** (d + 2)) - 2 * S_K2 / (n * (n - 1) * h ** (d + 2))
 
     return score, grad, float(hess)
 
@@ -329,22 +338,15 @@ def _newton_armijo_mv(
     h = h0
     for _ in range(max_iter):
         f, g, hess = lscv_mv(data, h, kernel)
-        if abs(g) < tol:
+        if _grad_converged(g, h, f, tol):
             break
-        step = (
-            -g / hess
-            if hess > 0 and np.isfinite(hess)
-            else (0.25 * h * np.sign(-g) if g != 0 else 0.0)
-        )
-        if abs(step) / h < 1e-3:
+        step = _newton_step(g, hess, h)
+        if step == 0.0:
             break
-        for _ in range(10):
-            h_new = max(h + step, 1e-6)
-            f_new = lscv_mv(data, h_new, kernel)[0]
-            if f_new < f:
-                h = h_new
-                break
-            step *= 0.5
+        accepted = _line_search(lambda hh: lscv_mv(data, hh, kernel)[0], h, step, f, 1e-6)
+        if accepted is None:
+            break
+        h = accepted[0]
     return h
 
 
@@ -358,22 +360,15 @@ def _newton_armijo_mv_numba(
     h = h0
     for _ in range(max_iter):
         f, g, hess = lscv_mv_numba_gauss(data, h)
-        if abs(g) < tol:
+        if _grad_converged(g, h, f, tol):
             break
-        step = (
-            -g / hess
-            if hess > 0 and np.isfinite(hess)
-            else (0.25 * h * np.sign(-g) if g != 0 else 0.0)
-        )
-        if abs(step) / h < 1e-3:
+        step = _newton_step(g, hess, h)
+        if step == 0.0:
             break
-        for _ in range(10):
-            h_new = max(h + step, 1e-6)
-            f_new = lscv_mv_numba_gauss(data, h_new)[0]
-            if f_new < f:
-                h = h_new
-                break
-            step *= 0.5
+        accepted = _line_search(lambda hh: lscv_mv_numba_gauss(data, hh)[0], h, step, f, 1e-6)
+        if accepted is None:
+            break
+        h = accepted[0]
     return h
 
 
@@ -484,7 +479,9 @@ def kde_evaluate_mv(
     if data_ev.ndim != 2:
         raise ValueError(f"data_eval must be 2D array, got shape {data_ev.shape}")
     if data_tr.shape[1] != data_ev.shape[1]:
-        raise ValueError(f"data_train and data_eval must have same number of dimensions, got {data_tr.shape[1]} and {data_ev.shape[1]}")
+        raise ValueError(
+            f"data_train and data_eval must have same number of dimensions, got {data_tr.shape[1]} and {data_ev.shape[1]}"
+        )
     if kernel not in _KERNELS:
         raise ValueError(f"kernel must be one of {list(_KERNELS.keys())}, got {kernel!r}")
 

--- a/hbw/kde.py
+++ b/hbw/kde.py
@@ -23,6 +23,7 @@ from ._numba_kde import (
     lscv_score_numba_unif,
 )
 from ._optim import (
+    _bandwidth_floor,
     _grad_converged,
     _line_search,
     _newton_armijo,
@@ -336,14 +337,15 @@ def _newton_armijo_mv(
 ) -> float:
     """Run Newton-Armijo optimization for multivariate bandwidth selection."""
     h = h0
+    h_floor = _bandwidth_floor(h0)
     for _ in range(max_iter):
         f, g, hess = lscv_mv(data, h, kernel)
-        if _grad_converged(g, h, f, tol):
+        if _grad_converged(g, h, f, hess, tol):
             break
         step = _newton_step(g, hess, h)
         if step == 0.0:
             break
-        accepted = _line_search(lambda hh: lscv_mv(data, hh, kernel)[0], h, step, f, 1e-6)
+        accepted = _line_search(lambda hh: lscv_mv(data, hh, kernel)[0], h, step, f, h_floor)
         if accepted is None:
             break
         h = accepted[0]
@@ -358,14 +360,15 @@ def _newton_armijo_mv_numba(
 ) -> float:
     """Run Newton-Armijo optimization for multivariate bandwidth selection with Numba."""
     h = h0
+    h_floor = _bandwidth_floor(h0)
     for _ in range(max_iter):
         f, g, hess = lscv_mv_numba_gauss(data, h)
-        if _grad_converged(g, h, f, tol):
+        if _grad_converged(g, h, f, hess, tol):
             break
         step = _newton_step(g, hess, h)
         if step == 0.0:
             break
-        accepted = _line_search(lambda hh: lscv_mv_numba_gauss(data, hh)[0], h, step, f, 1e-6)
+        accepted = _line_search(lambda hh: lscv_mv_numba_gauss(data, hh)[0], h, step, f, h_floor)
         if accepted is None:
             break
         h = accepted[0]

--- a/hbw/nw.py
+++ b/hbw/nw.py
@@ -23,7 +23,14 @@ from ._numba_nw import (
     loocv_score_numba_triweight,
     loocv_score_numba_unif,
 )
-from ._optim import _newton_armijo, _silverman_h, _subsample
+from ._optim import (
+    _grad_converged,
+    _line_search,
+    _newton_armijo,
+    _newton_step,
+    _silverman_h,
+    _subsample,
+)
 
 
 def _nw_weights(
@@ -31,11 +38,15 @@ def _nw_weights(
     h: float,
     kernel: str,
 ) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any]]:
-    """Return weights w, w', w'' for Nadaraya-Watson."""
+    """Return weights w, w', w'' for Nadaraya-Watson.
+
+    With u = delta/h the weight is w(h) = K(u)/h, so that
+    w' = -(K + u K')/h^2 and w'' = (2K + 4u K' + u^2 K'')/h^3.
+    """
     if kernel == "gauss":
         base = np.exp(-0.5 * u * u) / (h * _SQRT_2PI)
         w1 = base * (u * u - 1) / h
-        w2 = base * (u**4 - 3 * u * u + 1) / (h * h)
+        w2 = base * (u**4 - 5 * u * u + 2) / (h * h)
         return base, w1, w2
     elif kernel == "epan":
         mask = np.abs(u) <= 1
@@ -53,6 +64,8 @@ def _nw_weights(
         w[mask] = 0.5 / h
         w1 = np.zeros_like(u, dtype=float)
         w2 = np.zeros_like(u, dtype=float)
+        w1[mask] = -0.5 / (h * h)
+        w2[mask] = 1.0 / (h**3)
         return w, w1, w2
     elif kernel == "biweight":
         mask = np.abs(u) <= 1
@@ -63,7 +76,7 @@ def _nw_weights(
         one_minus_uu = 1 - uu
         w[mask] = (15 / 16) * one_minus_uu[mask] ** 2 / h
         w1[mask] = (15 / 16) * one_minus_uu[mask] * (5 * uu[mask] - 1) / (h * h)
-        w2[mask] = (15 / 8) * (1 - 12 * uu[mask] + 20 * uu[mask] ** 2 - 5 * uu[mask] ** 3) / (h**3)
+        w2[mask] = (15 / 8) * (1 - 12 * uu[mask] + 15 * uu[mask] ** 2) / (h**3)
         return w, w1, w2
     elif kernel == "triweight":
         mask = np.abs(u) <= 1
@@ -75,7 +88,7 @@ def _nw_weights(
         w[mask] = (35 / 32) * one_minus_uu[mask] ** 3 / h
         w1[mask] = (35 / 32) * one_minus_uu[mask] ** 2 * (7 * uu[mask] - 1) / (h * h)
         w2[mask] = (
-            (35 / 16) * one_minus_uu[mask] * (1 - 20 * uu[mask] + 35 * uu[mask] ** 2) / (h**3)
+            (35 / 16) * (1 - 18 * uu[mask] + 45 * uu[mask] ** 2 - 28 * uu[mask] ** 3) / (h**3)
         )
         return w, w1, w2
     elif kernel == "cosine":
@@ -88,17 +101,10 @@ def _nw_weights(
         sin_val = np.sin(np.pi * u / 2)
         pi = np.pi
         w[mask] = (pi / 4) * cos_val[mask] / h
-        w1[mask] = (
-            (pi / 4)
-            * ((pi**2 * uu[mask] / 4 - 1) * cos_val[mask] - (pi * u[mask] / 2) * sin_val[mask])
-            / (h * h)
-        )
+        w1[mask] = (pi / 4) * (-cos_val[mask] + (pi * u[mask] / 2) * sin_val[mask]) / (h * h)
         w2[mask] = (
             (pi / 4)
-            * (
-                (2 - 3 * pi**2 * uu[mask] / 2 + pi**4 * uu[mask] ** 2 / 16) * cos_val[mask]
-                + (3 * pi * u[mask] / 2 - pi**3 * uu[mask] * u[mask] / 8) * sin_val[mask]
-            )
+            * ((2 - pi**2 * uu[mask] / 4) * cos_val[mask] - 2 * pi * u[mask] * sin_val[mask])
             / (h**3)
         )
         return w, w1, w2
@@ -193,6 +199,7 @@ def _nw_weights_grad(
         w = np.zeros_like(u, dtype=float)
         w[mask] = 0.5 / h
         w1 = np.zeros_like(u, dtype=float)
+        w1[mask] = -0.5 / (h * h)
         return w, w1
     elif kernel == "biweight":
         mask = np.abs(u) <= 1
@@ -216,16 +223,11 @@ def _nw_weights_grad(
         mask = np.abs(u) <= 1
         w = np.zeros_like(u, dtype=float)
         w1 = np.zeros_like(u, dtype=float)
-        uu = u * u
         cos_val = np.cos(np.pi * u / 2)
         sin_val = np.sin(np.pi * u / 2)
         pi = np.pi
         w[mask] = (pi / 4) * cos_val[mask] / h
-        w1[mask] = (
-            (pi / 4)
-            * ((pi**2 * uu[mask] / 4 - 1) * cos_val[mask] - (pi * u[mask] / 2) * sin_val[mask])
-            / (h * h)
-        )
+        w1[mask] = (pi / 4) * (-cos_val[mask] + (pi * u[mask] / 2) * sin_val[mask]) / (h * h)
         return w, w1
     else:
         raise ValueError(f"Unknown kernel: {kernel}")
@@ -489,9 +491,11 @@ def loocv_mse_mv(
         with np.errstate(divide="ignore", invalid="ignore"):
             r = np.where(K_vals[:, :, k] != 0, Kp_vals[:, :, k] / K_vals[:, :, k], 0)
             r2 = np.where(K_vals[:, :, k] != 0, Kpp_vals[:, :, k] / K_vals[:, :, k], 0)
-        sum_d2 += 2.0 * U[:, :, k] * r + U[:, :, k] ** 2 * (r2 - r * r)
+        sum_d2 += U[:, :, k] ** 2 * (r2 - r * r)
 
-    w2 = (K_prod / (h * h)) * ((d + 1) * d + 2.0 * (d + 1) * sum_ratio + sum_d2)
+    # d2/dh2 [h^-d A] = h^-(d+2) A (d(d+1) + 2(d+1)S + S^2
+    #                                + sum_k U_k^2 (K''/K - (K'/K)^2))
+    w2 = (K_prod / (h * h)) * ((d + 1) * d + 2.0 * (d + 1) * sum_ratio + sum_ratio**2 + sum_d2)
     np.fill_diagonal(w2, 0.0)
     num2 = w2 @ y
     den2 = w2.sum(axis=1)
@@ -524,34 +528,21 @@ def _newton_armijo_mv_nw(
     f_prev = float("inf")
     for _ in range(max_iter):
         f, g, hess = loocv_mse_mv(data, y, h, kernel)
-        if abs(g) < tol:
+        if _grad_converged(g, h, f, tol):
             break
         if abs(f - f_prev) < 1e-8 * abs(f):
             break
         f_prev = f
 
-        if hess > 0 and np.isfinite(hess):
-            step = -g / hess
-            step = np.clip(step, -0.5 * h, 0.5 * h)
-        else:
-            step = 0.1 * h * np.sign(-g) if g != 0 else 0.0
-        if abs(step) / h < 1e-3:
+        step = _newton_step(g, hess, h)
+        if step == 0.0:
             break
-
-        h_new = max(h + step, 0.01 * h0)
-        f_new = loocv_mse_mv(data, y, h_new, kernel)[0]
-
-        if f_new < f:
-            h = h_new
-            continue
-
-        for _ in range(4):
-            step *= 0.5
-            h_new = max(h + step, 0.01 * h0)
-            f_new = loocv_mse_mv(data, y, h_new, kernel)[0]
-            if f_new < f:
-                h = h_new
-                break
+        accepted = _line_search(
+            lambda hh: loocv_mse_mv(data, y, hh, kernel)[0], h, step, f, 0.01 * h0
+        )
+        if accepted is None:
+            break
+        h = accepted[0]
     return h
 
 
@@ -567,34 +558,21 @@ def _newton_armijo_mv_nw_numba(
     f_prev = float("inf")
     for _ in range(max_iter):
         f, g, hess = loocv_mv_numba_gauss(data, y, h)
-        if abs(g) < tol:
+        if _grad_converged(g, h, f, tol):
             break
         if abs(f - f_prev) < 1e-8 * abs(f):
             break
         f_prev = f
 
-        if hess > 0 and np.isfinite(hess):
-            step = -g / hess
-            step = np.clip(step, -0.5 * h, 0.5 * h)
-        else:
-            step = 0.1 * h * np.sign(-g) if g != 0 else 0.0
-        if abs(step) / h < 1e-3:
+        step = _newton_step(g, hess, h)
+        if step == 0.0:
             break
-
-        h_new = max(h + step, 0.01 * h0)
-        f_new = loocv_score_mv_numba_gauss(data, y, h_new)
-
-        if f_new < f:
-            h = h_new
-            continue
-
-        for _ in range(4):
-            step *= 0.5
-            h_new = max(h + step, 0.01 * h0)
-            f_new = loocv_score_mv_numba_gauss(data, y, h_new)
-            if f_new < f:
-                h = h_new
-                break
+        accepted = _line_search(
+            lambda hh: loocv_score_mv_numba_gauss(data, y, hh), h, step, f, 0.01 * h0
+        )
+        if accepted is None:
+            break
+        h = accepted[0]
     return h
 
 
@@ -645,7 +623,9 @@ def nw_predict(
     x_te = np.asarray(x_test, dtype=float).ravel()
 
     if len(x_tr) != len(y_tr):
-        raise ValueError(f"x_train and y_train must have same length, got {len(x_tr)} and {len(y_tr)}")
+        raise ValueError(
+            f"x_train and y_train must have same length, got {len(x_tr)} and {len(y_tr)}"
+        )
     if kernel not in _KERNELS:
         raise ValueError(f"kernel must be one of {list(_KERNELS.keys())}, got {kernel!r}")
 
@@ -723,9 +703,13 @@ def nw_predict_mv(
     if data_te.ndim != 2:
         raise ValueError(f"data_test must be 2D array, got shape {data_te.shape}")
     if len(data_tr) != len(y_tr):
-        raise ValueError(f"data_train and y_train must have same length, got {len(data_tr)} and {len(y_tr)}")
+        raise ValueError(
+            f"data_train and y_train must have same length, got {len(data_tr)} and {len(y_tr)}"
+        )
     if data_tr.shape[1] != data_te.shape[1]:
-        raise ValueError(f"data_train and data_test must have same number of dimensions, got {data_tr.shape[1]} and {data_te.shape[1]}")
+        raise ValueError(
+            f"data_train and data_test must have same number of dimensions, got {data_tr.shape[1]} and {data_te.shape[1]}"
+        )
     if kernel not in _KERNELS:
         raise ValueError(f"kernel must be one of {list(_KERNELS.keys())}, got {kernel!r}")
 

--- a/hbw/nw.py
+++ b/hbw/nw.py
@@ -528,7 +528,7 @@ def _newton_armijo_mv_nw(
     f_prev = float("inf")
     for _ in range(max_iter):
         f, g, hess = loocv_mse_mv(data, y, h, kernel)
-        if _grad_converged(g, h, f, tol):
+        if _grad_converged(g, h, f, hess, tol):
             break
         if abs(f - f_prev) < 1e-8 * abs(f):
             break
@@ -558,7 +558,7 @@ def _newton_armijo_mv_nw_numba(
     f_prev = float("inf")
     for _ in range(max_iter):
         f, g, hess = loocv_mv_numba_gauss(data, y, h)
-        if _grad_converged(g, h, f, tol):
+        if _grad_converged(g, h, f, hess, tol):
             break
         if abs(f - f_prev) < 1e-8 * abs(f):
             break

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -54,3 +54,133 @@ def test_loocv_mse_grad_matches_loocv_mse() -> None:
             loss_grad, grad_grad = loocv_mse_grad(x, y, h, kernel)
             assert math.isclose(loss_full, loss_grad, rel_tol=1e-10)
             assert math.isclose(grad_full, grad_grad, rel_tol=1e-10)
+
+
+KERNELS = ["gauss", "epan", "unif", "biweight", "triweight", "cosine"]
+
+
+def fd_hessian(f, h: float, eps: float) -> float:
+    """Central second difference of f at h."""
+    return (f(h + eps) - 2 * f(h) + f(h - eps)) / eps**2
+
+
+def fd_gradient(f, h: float, eps: float) -> float:
+    """Central first difference of f at h."""
+    return (f(h + eps) - f(h - eps)) / (2 * eps)
+
+
+def _sample(seed: int, n: int = 60):
+    """Draw a reproducible (x, y) pair for derivative checks."""
+    rng = np.random.default_rng(seed)
+    x = rng.normal(size=n)
+    y = np.sin(x) + 0.2 * rng.normal(size=n)
+    return x, y
+
+
+def test_lscv_hessian_against_finite_diff() -> None:
+    """The LSCV Hessian must be the second derivative of the LSCV score.
+
+    The published Hessian used to collapse to exactly -2 * grad / h, because the
+    correction term summed a function odd in u over a symmetric matrix and was
+    therefore identically zero.
+    """
+    x, _ = _sample(7)
+    for kernel in KERNELS:
+        for h in (0.45, 0.8):
+            _, _, hess = lscv(x, h, kernel)
+            fd = fd_hessian(lambda hh, k=kernel: lscv(x, hh, k)[0], h, 1e-4)
+            assert math.isclose(hess, fd, rel_tol=1e-3, abs_tol=1e-6), (
+                f"{kernel} h={h}: analytic {hess} vs finite difference {fd}"
+            )
+
+
+def test_lscv_hessian_is_not_proportional_to_gradient() -> None:
+    """Guard the specific degeneracy: hess == -2 * grad / h for every kernel."""
+    x, _ = _sample(7)
+    for kernel in KERNELS:
+        _, grad, hess = lscv(x, 0.45, kernel)
+        assert not math.isclose(hess, -2 * grad / 0.45, rel_tol=1e-6)
+
+
+def test_lscv_hessian_converges_quadratically() -> None:
+    """Halving the step must cut the finite-difference error roughly fourfold."""
+    x, _ = _sample(7)
+    _, _, hess = lscv(x, 0.45, "gauss")
+    errs = [
+        abs(fd_hessian(lambda hh: lscv(x, hh, "gauss")[0], 0.45, eps) - hess)
+        for eps in (1e-2, 1e-3)
+    ]
+    assert errs[1] < errs[0] / 50
+
+
+def test_loocv_mse_gradient_against_finite_diff() -> None:
+    """The LOOCV-MSE gradient must match finite differences for every kernel.
+
+    The cosine weight derivative used to carry a spurious (pi*u/2)**2 * cos term
+    and the wrong sign on the sine term.
+    """
+    x, y = _sample(7)
+    for kernel in KERNELS:
+        for h in (0.45, 0.8):
+            _, grad, _ = loocv_mse(x, y, h, kernel)
+            fd = fd_gradient(lambda hh, k=kernel: loocv_mse(x, y, hh, k)[0], h, 1e-4)
+            assert math.isclose(grad, fd, rel_tol=1e-3, abs_tol=1e-9), (
+                f"{kernel} h={h}: analytic {grad} vs finite difference {fd}"
+            )
+
+
+def test_loocv_mse_hessian_against_finite_diff() -> None:
+    """The LOOCV-MSE Hessian must be the second derivative of the loss."""
+    x, y = _sample(7)
+    for kernel in KERNELS:
+        if kernel == "unif":
+            continue  # loss is locally constant in h; both sides are ~0
+        for h in (0.45, 0.8):
+            _, _, hess = loocv_mse(x, y, h, kernel)
+            fd = fd_hessian(lambda hh, k=kernel: loocv_mse(x, y, hh, k)[0], h, 1e-4)
+            assert math.isclose(hess, fd, rel_tol=1e-3, abs_tol=1e-8), (
+                f"{kernel} h={h}: analytic {hess} vs finite difference {fd}"
+            )
+
+
+def test_lscv_mv_hessian_against_finite_diff() -> None:
+    """The multivariate LSCV Hessian must match finite differences."""
+    from hbw.kde import lscv_mv
+
+    rng = np.random.default_rng(7)
+    data = rng.normal(size=(50, 2))
+    for h in (0.6, 0.9):
+        _, _, hess = lscv_mv(data, h, "gauss")
+        fd = fd_hessian(lambda hh: lscv_mv(data, hh, "gauss")[0], h, 1e-4)
+        assert math.isclose(hess, fd, rel_tol=1e-4)
+
+
+def test_loocv_mse_mv_hessian_against_finite_diff() -> None:
+    """The multivariate LOOCV-MSE Hessian must match finite differences."""
+    from hbw.nw import loocv_mse_mv
+
+    rng = np.random.default_rng(7)
+    data = rng.normal(size=(50, 2))
+    y = np.sin(data[:, 0]) + 0.2 * rng.normal(size=50)
+    for h in (0.6, 0.9):
+        _, _, hess = loocv_mse_mv(data, y, h, "gauss")
+        fd = fd_hessian(lambda hh: loocv_mse_mv(data, y, hh, "gauss")[0], h, 1e-4)
+        assert math.isclose(hess, fd, rel_tol=1e-4)
+
+
+def test_nw_weight_derivatives_against_finite_diff() -> None:
+    """w' and w'' returned by _nw_weights must be derivatives of w in h."""
+    from hbw.nw import _nw_weights
+
+    delta = np.array([0.0, 0.05, 0.12, -0.2, 0.31, -0.45, 0.5])
+    h, eps = 0.7, 1e-4
+
+    def w_at(hh: float) -> np.ndarray:
+        return _nw_weights(delta / hh, hh, kernel)[0]
+
+    for kernel in KERNELS:
+        _, w1, w2 = _nw_weights(delta / h, h, kernel)
+        fd1 = (w_at(h + eps) - w_at(h - eps)) / (2 * eps)
+        fd2 = (w_at(h + eps) - 2 * w_at(h) + w_at(h - eps)) / eps**2
+        assert np.max(np.abs(fd1 - w1)) < 1e-5, kernel
+        assert np.max(np.abs(fd2 - w2)) < 1e-4, kernel

--- a/tests/test_newton.py
+++ b/tests/test_newton.py
@@ -4,8 +4,11 @@ import math
 import random
 
 import numpy as np
+from scipy.optimize import minimize_scalar
 
-from hbw import kde_bandwidth, lscv
+from hbw import kde_bandwidth, lscv, nw_bandwidth
+from hbw.kde import lscv_score
+from hbw.nw import loocv_mse_score
 
 
 def mixture_sample(n: int, rng: random.Random) -> np.ndarray:
@@ -30,6 +33,57 @@ def test_newton_matches_grid_search() -> None:
 
         h_newton = kde_bandwidth(x, kernel=kernel, h0=h_grid * 1.1, max_n=None)
         assert math.isclose(h_newton, h_grid, rel_tol=0.1, abs_tol=0.05)
+
+
+def test_gaussian_selectors_match_scipy_bounded_minimization() -> None:
+    """Gaussian selectors must match an independent derivative-free optimizer."""
+    rng = np.random.default_rng(2026)
+    x = rng.normal(size=300)
+    y = np.sin(x) + 0.2 * rng.normal(size=300)
+    scale = np.std(x, ddof=1)
+    bounds = (math.log(0.01 * scale), math.log(3.0 * scale))
+
+    kde_reference = minimize_scalar(
+        lambda log_h: lscv_score(x, math.exp(log_h)),
+        bounds=bounds,
+        method="bounded",
+        options={"xatol": 1e-11},
+    )
+    assert kde_reference.success
+    h_kde = kde_bandwidth(x, max_n=None)
+    assert math.isclose(h_kde, math.exp(kde_reference.x), rel_tol=1e-3)
+    assert lscv_score(x, h_kde) <= kde_reference.fun + 1e-9
+
+    nw_reference = minimize_scalar(
+        lambda log_h: loocv_mse_score(x, y, math.exp(log_h)),
+        bounds=bounds,
+        method="bounded",
+        options={"xatol": 1e-11},
+    )
+    assert nw_reference.success
+    h_nw = nw_bandwidth(x, y, max_n=None)
+    assert math.isclose(h_nw, math.exp(nw_reference.x), rel_tol=1e-3)
+    assert loocv_mse_score(x, y, h_nw) <= nw_reference.fun + 1e-9
+
+
+def test_selectors_match_dense_log_grid_objectives() -> None:
+    """Optimized scores must agree with a slow dense-grid oracle across kernels."""
+    rng = np.random.default_rng(31)
+    x = np.concatenate((rng.normal(-1.0, 0.45, 40), rng.normal(1.0, 0.7, 40)))
+    y = np.sin(x) + 0.2 * rng.normal(size=len(x))
+    grid = np.geomspace(0.02, 3.0, 800)
+
+    for kernel in ALL_KERNELS:
+        h = kde_bandwidth(x, kernel=kernel, max_n=None)
+        selected = lscv_score(x, h, kernel)
+        grid_min = min(lscv_score(x, candidate, kernel) for candidate in grid)
+        assert selected - grid_min <= 1e-3 * abs(grid_min), kernel
+
+    for kernel in ("gauss", "epan", "biweight", "triweight", "cosine"):
+        h = nw_bandwidth(x, y, kernel=kernel, max_n=None)
+        selected = loocv_mse_score(x, y, h, kernel)
+        grid_min = min(loocv_mse_score(x, y, candidate, kernel) for candidate in grid)
+        assert selected - grid_min <= 1e-3 * grid_min, kernel
 
 
 def test_kde_bandwidth_basic() -> None:
@@ -74,7 +128,7 @@ def test_kde_bandwidth_is_scale_equivariant() -> None:
     x = np.random.default_rng(11).normal(size=400)
     for kernel in ALL_KERNELS:
         h1 = kde_bandwidth(x, kernel=kernel)
-        for c in (100.0, 1000.0, 1e5):
+        for c in (1e-6, 1e-4, 1e-2, 100.0, 1000.0, 1e5):
             hc = kde_bandwidth(c * x, kernel=kernel)
             assert math.isclose(hc / c, h1, rel_tol=1e-6), f"{kernel} c={c}: {hc / c} vs {h1}"
 
@@ -88,7 +142,7 @@ def test_nw_bandwidth_is_scale_equivariant() -> None:
     y = np.sin(x) + 0.2 * rng.normal(size=400)
     for kernel in ALL_KERNELS:
         h1 = nw_bandwidth(x, y, kernel=kernel)
-        for c in (100.0, 1000.0, 1e5):
+        for c in (1e-6, 1e-4, 1e-2, 100.0, 1000.0, 1e5):
             hc = nw_bandwidth(c * x, y, kernel=kernel)
             assert math.isclose(hc / c, h1, rel_tol=1e-6), f"{kernel} c={c}: {hc / c} vs {h1}"
 
@@ -114,12 +168,43 @@ def test_grad_converged_handles_a_criterion_passing_through_zero():
     _grad_converged scaled the gradient test by abs(f) and returned False
     outright when that scale was zero, so an iterate sitting at f == 0 with a
     negligible gradient could never converge and burned the whole iteration
-    budget. It now falls back to an absolute test at that single point.
+    budget. It now tests the relative Newton step at that single point.
     """
     from hbw._optim import _grad_converged
 
-    assert _grad_converged(g=1e-12, h=1.0, f=0.0, tol=1e-5)
-    assert not _grad_converged(g=1.0, h=1.0, f=0.0, tol=1e-5)
+    assert _grad_converged(g=1e-12, h=1.0, f=0.0, hess=1.0, tol=1e-5)
+    assert not _grad_converged(g=1.0, h=1.0, f=0.0, hess=1.0, tol=1e-5)
+    assert _grad_converged(g=0.0, h=1.0, f=0.0, hess=0.0, tol=1e-5)
+    assert not _grad_converged(g=1e-12, h=1.0, f=0.0, hess=-1.0, tol=1e-5)
     # A non-zero scale is unaffected.
-    assert _grad_converged(g=1e-12, h=1.0, f=2.0, tol=1e-5)
-    assert not _grad_converged(g=1e-4, h=1.0, f=1.0, tol=1e-5)
+    assert _grad_converged(g=1e-12, h=1.0, f=2.0, hess=1.0, tol=1e-5)
+    assert not _grad_converged(g=1e-4, h=1.0, f=1.0, hess=1.0, tol=1e-5)
+
+
+def test_grad_converged_at_zero_is_scale_equivariant() -> None:
+    """Equivalent LSCV states must make the same convergence decision at f=0."""
+    from hbw._optim import _grad_converged
+
+    for g, expected in ((1e-6, True), (1e-4, False)):
+        base = _grad_converged(g=g, h=1.0, f=0.0, hess=1.0, tol=1e-5)
+        assert base is expected
+        for c in (1e-6, 1e6):
+            scaled = _grad_converged(
+                g=g / c**2,
+                h=c,
+                f=0.0,
+                hess=1.0 / c**3,
+                tol=1e-5,
+            )
+            assert scaled is expected
+
+
+def test_kde_bandwidth_mv_is_scale_equivariant_without_standardization() -> None:
+    """The multivariate optimizer floor must scale with the input units."""
+    from hbw import kde_bandwidth_mv
+
+    data = np.random.default_rng(11).normal(size=(200, 2))
+    h1 = kde_bandwidth_mv(data, standardize=False)
+    for c in (1e-6, 1e6):
+        hc = kde_bandwidth_mv(c * data, standardize=False)
+        assert math.isclose(hc / c, h1, rel_tol=1e-6)

--- a/tests/test_newton.py
+++ b/tests/test_newton.py
@@ -46,3 +46,63 @@ def test_kde_bandwidth_subsampling() -> None:
     x = rng.normal(0, 1, 10000)
     h = kde_bandwidth(x, max_n=500, seed=42)
     assert 0.1 < h < 2.0
+
+
+ALL_KERNELS = ["gauss", "epan", "unif", "biweight", "triweight", "cosine"]
+
+
+def test_lscv_objective_is_scale_equivariant() -> None:
+    """c * LSCV(c*x, c*h) == LSCV(x, h): the identity the selector must inherit."""
+    from hbw.kde import lscv_score
+
+    x = np.random.default_rng(11).normal(size=200)
+    for kernel in ALL_KERNELS:
+        base = lscv_score(x, 0.35, kernel)
+        for c in (1e-3, 10.0, 1e4):
+            scaled = c * lscv_score(c * x, c * 0.35, kernel)
+            assert math.isclose(scaled, base, rel_tol=1e-12)
+
+
+def test_kde_bandwidth_is_scale_equivariant() -> None:
+    """kde_bandwidth(c*x) must equal c * kde_bandwidth(x).
+
+    The LSCV gradient scales like 1/c**2, so an absolute gradient tolerance made
+    large-unit data converge immediately and return Silverman's rule untouched.
+    """
+    from hbw import kde_bandwidth
+
+    x = np.random.default_rng(11).normal(size=400)
+    for kernel in ALL_KERNELS:
+        h1 = kde_bandwidth(x, kernel=kernel)
+        for c in (100.0, 1000.0, 1e5):
+            hc = kde_bandwidth(c * x, kernel=kernel)
+            assert math.isclose(hc / c, h1, rel_tol=1e-6), f"{kernel} c={c}: {hc / c} vs {h1}"
+
+
+def test_nw_bandwidth_is_scale_equivariant() -> None:
+    """nw_bandwidth(c*x, y) must equal c * nw_bandwidth(x, y)."""
+    from hbw import nw_bandwidth
+
+    rng = np.random.default_rng(11)
+    x = rng.normal(size=400)
+    y = np.sin(x) + 0.2 * rng.normal(size=400)
+    for kernel in ALL_KERNELS:
+        h1 = nw_bandwidth(x, y, kernel=kernel)
+        for c in (100.0, 1000.0, 1e5):
+            hc = nw_bandwidth(c * x, y, kernel=kernel)
+            assert math.isclose(hc / c, h1, rel_tol=1e-6), f"{kernel} c={c}: {hc / c} vs {h1}"
+
+
+def test_numba_loocv_score_matches_numpy_when_weights_underflow() -> None:
+    """A bandwidth so small that every weight underflows must not score as zero."""
+    from hbw._numba_nw import loocv_numba_gauss, loocv_score_numba_gauss
+    from hbw.nw import loocv_mse_score
+
+    rng = np.random.default_rng(42)
+    x = np.linspace(-2, 2, 200)
+    y = np.sin(x) + 0.1 * rng.standard_normal(200)
+    for h in (1e-6, 1e-4):
+        expected = loocv_mse_score(x, y, h, "gauss")
+        assert expected > 0.1
+        assert math.isclose(loocv_score_numba_gauss(x, y, h), expected, rel_tol=1e-12)
+        assert math.isclose(loocv_numba_gauss(x, y, h)[0], expected, rel_tol=1e-12)

--- a/tests/test_newton.py
+++ b/tests/test_newton.py
@@ -106,3 +106,20 @@ def test_numba_loocv_score_matches_numpy_when_weights_underflow() -> None:
         assert expected > 0.1
         assert math.isclose(loocv_score_numba_gauss(x, y, h), expected, rel_tol=1e-12)
         assert math.isclose(loocv_numba_gauss(x, y, h)[0], expected, rel_tol=1e-12)
+
+
+def test_grad_converged_handles_a_criterion_passing_through_zero():
+    """A zero criterion value used to make convergence unreachable.
+
+    _grad_converged scaled the gradient test by abs(f) and returned False
+    outright when that scale was zero, so an iterate sitting at f == 0 with a
+    negligible gradient could never converge and burned the whole iteration
+    budget. It now falls back to an absolute test at that single point.
+    """
+    from hbw._optim import _grad_converged
+
+    assert _grad_converged(g=1e-12, h=1.0, f=0.0, tol=1e-5)
+    assert not _grad_converged(g=1.0, h=1.0, f=0.0, tol=1e-5)
+    # A non-zero scale is unaffected.
+    assert _grad_converged(g=1e-12, h=1.0, f=2.0, tol=1e-5)
+    assert not _grad_converged(g=1e-4, h=1.0, f=1.0, tol=1e-5)


### PR DESCRIPTION
Three defects in the package's headline feature. Each fix ships with a test confirmed to
fail without it.

## 1. None of the four "analytic Hessian" functions returned a Hessian

`lscv`, `lscv_mv`, `loocv_mse` and `loocv_mse_mv` are documented as returning
`(score, gradient, hessian)`. The returned third value was identically `-2 * grad / h`.

Root cause in `kde.py`: the second-derivative term was `h^-2 (2 K2' + u K2'')` with a minus
sign, where the correct identity is

```
d²/dh² [ h^-1 f(delta/h) ] = h^-3 ( 2f + 4u f' + u² f'' )
```

Both summands of the coded version are **odd in u**, so over the symmetric pair matrix they
sum to exactly zero — leaving the gradient term alone, rescaled.

The Gaussian kernel is C-infinity, so finite differences are an unimpeachable oracle here.
On `main`, at h=0.45:

```
analytic "Hessian"      1.4017277993e-01
-2 * grad / h           1.4017277993e-01      <- identical to 16 digits
FD eps=1e-2             3.0126954735e-01
FD eps=1e-3             3.0114810343e-01
FD eps=1e-4             3.0114688243e-01      <- the true value
```

Ratio `H / (-2 grad/h)` = 0.9999999999999992. After the fix, analytic gives
3.0114687620e-01 against FD's 3.0114688243e-01 — agreement to 8 significant figures.

The sign was wrong in three of the four functions. Consequences: in 1-D the Newton step was
`-g/H = h/2` always, i.e. a fixed geometric search; in the multivariate case the Hessian came
out negative at 24 of 25 bandwidths, so `if hess > 0` never fired and no Newton step was ever
taken.

Corroborating the intended formula: the numba `epan` and `unif` kernels already used the
correct general form `(2K + 4uK' + u²K'')/h³`.

`tests/test_derivatives.py` checked gradients against finite differences but never the
Hessian, which is why this survived 77 green tests.

## 2. The cosine-kernel NW weight derivative was wrong

Not merely a sign error. The code had `(pi/4)[(pi²u²/4 - 1)cos - (pi u/2) sin]/h²`; the
correct value is `(pi/4)[-cos + (pi/2) u sin]/h²` — a flipped sine sign **and** a spurious
`(pi²u²/4)cos` term. Present identically in `_nw_weights`, `_nw_weights_grad` and the numba
path, so all three agreed with each other and disagreed with the truth:

```
cosine LOOCV-MSE gradient at h=1.0
  analytic (all three paths)   +1.8333e-03
  central finite difference    -2.1351e-03     (stable at eps 1e-3 and 1e-4)
```

Wrong sign, so `nw_bandwidth(kernel="cosine")` walked uphill and returned Silverman's rule
unchanged.

## 3. Bandwidths depended on the units the data was measured in

`_optim.py` used an absolute gradient tolerance `tol=1e-5`, while the LSCV gradient scales as
`1/c²` under `x -> c x`.

The premise was established first: the LSCV objective *is* exactly scale-equivariant
(`c * LSCV(c x, c h) == LSCV(x, h)` to 1.8e-16), so a violation in the returned `h` is a
genuine defect rather than expected behaviour. Measuring `h(c x) / (c h(x))`, which must be
1.0000:

| c | gauss | epan | biweight | cosine | unif |
|---|---|---|---|---|---|
| 1 | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
| 10 | 1.0000 | 0.6709 | 1.0000 | 1.0000 | 1.0000 |
| 100 | 0.6667 | 0.2982 | 1.4361 | 0.2982 | 1.0000 |
| 1000 | 0.6667 | 0.2982 | 1.4361 | 0.2982 | 1.7147 |

At c >= 100 several kernels return the untouched Silverman start — a 172% error for gauss.
After the fix, 1.0000 everywhere, and scale equivariance holds to <= 6e-12 across all 12
kernel/estimator combinations.

## Two regressions the Hessian fix itself introduced, and how they were handled

Both would have shipped silently.

1. **With honest curvature, the Newton step on compact-kernel criteria crawled** and the
   15-iteration cap bound: `kde_bandwidth_mv(kernel="epan")` fell to 0.474 against a true
   minimiser of 0.889. Raising `max_iter` to 300 walked it to 0.858, which confirms budget
   exhaustion rather than a wrong derivative. The line search now **forward-tracks** (doubles
   while the score keeps falling) as well as backtracking. Near a genuine quadratic minimum
   the first doubling is rejected, so local convergence is untouched. mv epan now matches a
   grid to within 0.6% on all four seeds tested.
2. **The forward-tracking exposed a latent defect**: the numba LOOCV scorers *skipped* any
   point whose weights had all underflowed, so h=1e-6 scored exactly 0.0 against the NumPy
   reference's 0.603 — a fake global minimum the new line search could now actually reach.
   Fixed to agree with NumPy.

## Accuracy after the fix

1-D KDE against a 400-point grid, in |log(h/h_grid)|: gauss 0.023 -> 0.009, biweight
0.016 -> 0.003, triweight 0.009 -> 0.003. NW cosine 0.47 -> 0.39. mv KDE matches grid to 0.6%.

**One honest regression:** 1-D `kde_bandwidth(kernel="cosine")` worst case over 5 seeds went
0.018 -> 0.103. On the single offending seed, Newton lands at h=0.5051 with LSCV -0.23667063
where the grid minimum is h=0.4556 at -0.23673931 — a neighbouring local minimum of a
multi-modal C0-kernel criterion, 0.03% worse in objective. Not a derivative error. `unif`
remains poor (|log| ~ 1.3) both before and after; that is pre-existing.

## Not verified

`epan` and `cosine` LSCV Hessians have no independent numeric reference: both kernels are C0
but not C1, so the true second derivative carries singular terms and finite differences do
not converge. The `H = -2g/h` identity still proves the old value was not a Hessian, but a
correct number for those two could not be produced.

## Tests

77 -> **89 passed**. `ruff check`, `ruff format --check`, `mypy`, `pydoclint` and `vulture`
all pass.
